### PR TITLE
Values in the .ini file must be unquoted

### DIFF
--- a/balloon.ini
+++ b/balloon.ini
@@ -1,17 +1,17 @@
 [main]
 push_habhub = True
-habhub_callsign = "replaceme"
+habhub_callsign = replaceme
 
 push_aprs = True
 
 # This is the callsign the object comes from. This should NOT have any SSID's on it (i.e. -9) 
-aprsCallsign = "myhamcall"
+aprsCallsign = myhamcall
 
 # Replace with your own callsign. This should NOT have any SSID's on it (i.e. -9)
-aprsUser = 'myaprsisuser'
+aprsUser = myaprsisuser
 
 # APRS-IS passcode for your callsign.
-aprsPass = 'myaprsispass' 
+aprsPass = myaprsispass
 
 push_html = False
 push_ftp = False


### PR DESCRIPTION
Adding quotes results in sending of data with escaped quotes in it, example:

"LY1XX">APRS:;LY1XX-1 *111111z5441.25N/02517.50EO000/000/A=000590Temp=21.4C Solar=4.56V

Also, login to APRS-IS fails if aprsUser/aprsPass are given with quotes.