### PR TITLE
Error in Habhub checksum format breaks Habhub upload

### DIFF
--- a/telemetry.py
+++ b/telemetry.py
@@ -574,7 +574,7 @@ def process_telemetry(spots, balloons, habhub_callsign, push_habhub, push_aprs, 
                             while i < len(telestr):
                                 checksum = checksum ^ ord(telestr[i])
                                 i+=1
-                            telestr = "$$" + telestr + "*" + '{:x}'.format(int(checksum))
+                            telestr = "$$" + telestr + "*" + '{:02x}'.format(int(checksum))
                             logging.info("Telemetry: %s", telestr)
 
                             # Check if string has been uploaded before and if not then add and upload


### PR DESCRIPTION
Error in Habhub checksum code breaks Habhub upload if the first character in the checksum is a Zero - so now forced to always be 2 characters.  I found the bug live this evening, fixed, and confirmed working now.